### PR TITLE
[Python] #15 remove playground. in import

### DIFF
--- a/playground/bot.py
+++ b/playground/bot.py
@@ -1,6 +1,6 @@
 from typing import List
 from random import randint
-from playground.board import Stone
+from board import Stone
 
 
 class Bot:

--- a/playground/house.py
+++ b/playground/house.py
@@ -1,9 +1,9 @@
 import os
 from random import random
-from playground.board import Board
-from playground.referee import Referee
-from playground.player import Player
-from playground.bot import Bot
+from board import Board
+from referee import Referee
+from player import Player
+from bot import Bot
 
 if not os.path.exists("templates"):
     os.mkdir("templates")

--- a/playground/player.py
+++ b/playground/player.py
@@ -1,4 +1,4 @@
-from playground.board import Stone
+from board import Stone
 
 
 class Player:

--- a/playground/referee.py
+++ b/playground/referee.py
@@ -1,6 +1,6 @@
 from typing import List, DefaultDict
 from collections import defaultdict
-from playground.board import Board, Stone
+from board import Board, Stone
 
 
 # TODO : sparse


### PR DESCRIPTION
IDE 기준에서는 source directory를 수동으로 설정하기 때문에
import 할 때 "playgroud." 을 추가했는데,
콘솔에서 server.py를 실행하면, server.py가 속한 곳의 바로 상위 디렉토리를 source로 자동으로 잡기 때문에
"playground." 이 있으면 오류가 남 --> 결론은 다 지움